### PR TITLE
Select Node Update

### DIFF
--- a/Coordinate.cc
+++ b/Coordinate.cc
@@ -28,13 +28,13 @@ CoordinateArray::CoordinateArray(int size){
 }
 
 // dynamic allocation of coordinate array, creates new copies of data (static coordinate objects)
-CoordinateArray::CoordinateArray(CoordinateArray* cArr){
-    this->backArrSize = cArr->backArrSize;
-    this->elements = new Coordinate[cArr->backArrSize];
-    this->numElements = cArr->numElements;
+CoordinateArray::CoordinateArray(const CoordinateArray& cArr){
+    this->backArrSize = cArr.backArrSize;
+    this->elements = new Coordinate[cArr.backArrSize];
+    this->numElements = cArr.numElements;
 
-    for(int i = 0; i<cArr->numElements; ++i){
-        this->elements[i] = Coordinate(cArr->elements[i]);
+    for(int i = 0; i<cArr.numElements; ++i){
+        this->elements[i] = Coordinate(cArr.elements[i]);
     }
 }
 
@@ -47,7 +47,7 @@ CoordinateArray::~CoordinateArray(){
 Coordinate& CoordinateArray::operator[](int index) const{
     if (index < 0 || index >= this->numElements) {
 		cout<<"\n CoordinateArray ERROR [ "<< index << " ] ***** Coordinate Array indexing out of bounds *****"<<endl;
-        static Coordinate badCoord(-1,-1);
+        static Coordinate badCoord(-1,-1);  // static implemented to reference the coordinate globally for the reference return
         return badCoord;
 	}
 	return this->elements[index];
@@ -85,6 +85,16 @@ CoordinateArray& CoordinateArray::operator-=(const Coordinate& c){
 		this->elements[i] = this->elements[i + 1];        // shift elements
 		++i;
 	}
+	return *this;
+}
+
+// overload -- operator for convenient removing from collection object from the back, handles empty
+CoordinateArray& CoordinateArray::operator--()
+{
+    if (this->numElements > 0)
+    {
+        --this->numElements;
+    }
 	return *this;
 }
 

--- a/Coordinate.cc
+++ b/Coordinate.cc
@@ -46,8 +46,9 @@ CoordinateArray::~CoordinateArray(){
 // overload [] operator for convenient indexing / random acces to collection object, checks array bounds
 Coordinate& CoordinateArray::operator[](int index) const{
     if (index < 0 || index >= this->numElements) {
-		cerr<<"\nCoordinate Array indexing out of bounds"<<endl;
-		exit(1);
+		cout<<"\n CoordinateArray ERROR [ "<< index << " ] ***** Coordinate Array indexing out of bounds *****"<<endl;
+        static Coordinate badCoord(-1,-1);
+        return badCoord;
 	}
 	return this->elements[index];
 }
@@ -108,7 +109,7 @@ bool CoordinateArray::contains(const Coordinate& c) const{
 void CoordinateArray::print() const{
     cout << endl;
     for(int i = 0; i< this->numElements; ++i){
-        cout << this->elements[i] << endl;
+        cout << setw(5) << (i+1) << " : "<< this->elements[i] << endl;
     }
 }
 

--- a/Coordinate.h
+++ b/Coordinate.h
@@ -65,12 +65,13 @@ class CoordinateArray {
       public:
 
           CoordinateArray(int size = DEFAULT_ARRAY_SIZE);               // dynamic allocation of array of coordinates
-          CoordinateArray(CoordinateArray* cArr);       // dynamic allocation of array of coordinates, creates new copies of data (static coordinate objects)
+          CoordinateArray(const CoordinateArray& cArr);       // dynamic allocation of array of coordinates, creates new copies of data (static coordinate objects)
           ~CoordinateArray();
 
           Coordinate& operator[](int i) const;              // overload [] operator for convenient indexing / random acces to collection object, checks array bounds
           CoordinateArray& operator+=(const Coordinate& c); // overload += operator for convenient adding to collection object, handles resizing
           CoordinateArray& operator-=(const Coordinate& c); // overload -= operator for convenient removing from collection object, handles shifting
+          CoordinateArray& operator--(); // overload -- operator for convenient removing from collection object from the back, handles empty
 
 
           int getSize() const;
@@ -80,7 +81,7 @@ class CoordinateArray {
 
       private:
           int numElements;      // size of elements array
-          Coordinate* elements; // dynamic allocated array of T objects (can be pointers)
+          Coordinate* elements; // dynamic allocated array of Coordinate objects 
           int backArrSize;      // number of elements in backing array (will be resized)
 };
 

--- a/Map.cc
+++ b/Map.cc
@@ -7,15 +7,12 @@ Map::Map( int maxBaseDimension, int numSelectNodes ){
 
     ExpandedMatrix expandedMatrix(maxBaseDimension); // makes expanded matrix with new dimensions nxn, n = dimension + (dimension-1)
 
-    expandedMatrix.removeCommonLoops(); // removes a random 2 on for a room that has four 2s adjacent to it. Makes an aestetic looking map, try commenting it outCLEARCOMMENT
+    expandedMatrix.removeCommonLoops(); // removes a random 2 on for a room that has four 2s adjacent to it. Makes an aestetic looking map
 
-    MapFoundation mapFoundation(&expandedMatrix); // Foundation crops map and removes rooms/doors not accessible to starting locationCLEARCOMMENT
-
-    if (numSelectNodes < MINIMUM_SELECT_NODES) numSelectNodes = MINIMUM_SELECT_NODES;
-    this->selectNodesCount = numSelectNodes;
+    MapFoundation mapFoundation(&expandedMatrix); // Foundation crops map and removes nodes/edges not accessible to main starting location / selectNode
 
     try{
-        copyMapData(mapFoundation); // if there is an invalid matrix from mapFoundation there will be an error thrown instead of a crash
+        copyMapData(mapFoundation, numSelectNodes); // if there is an invalid matrix from mapFoundation there will be an error thrown instead of a crash
     } catch(const string& error){
         cout << endl<< " * MAP: FAILED TO COPY MAP DATA * " << error << endl;
     }
@@ -32,7 +29,7 @@ Map::~Map(){
     delete this->adjacencyListTable;
 }
 
-void Map::copyMapData(const MapFoundation& mapFoundation){
+void Map::copyMapData(const MapFoundation& mapFoundation, int numSelectNodes){
     if(DEBUG)cout << "\nMap::copyMapData | LINE:" << __LINE__ << endl;
 
     // the following is assigning the pointers to the map data generated in mapFoundation object
@@ -44,7 +41,10 @@ void Map::copyMapData(const MapFoundation& mapFoundation){
     setMapStart1((*this->nodes)[0]); // set the starting location to the same
     setMapStart2((*this->nodes)[this->nodes->getSize()-1]); // set the starting location to the same
 
-    for(int i = 0; i< this->selectNodesCount; ++i)
+    if (numSelectNodes < MINIMUM_SELECT_NODES) numSelectNodes = MINIMUM_SELECT_NODES;
+    else if (numSelectNodes > getNumNodes()) numSelectNodes = getNumNodes();
+
+    for(int i = 0; i < numSelectNodes; ++i)
     {
         if (i==0)
         {
@@ -70,11 +70,11 @@ void Map::mapDebug(const ExpandedMatrix& expandedMatrix, const MapFoundation& ma
 
     pBreak();
     cout << "expandedMatrix.print()" << endl;
-    expandedMatrix.print();         // print base matrix of only 1s and 0s before expandCLEARCOMMENT
+    expandedMatrix.print();
 
     pBreak();
     cout << "expandedMatrix.printExpanded()" << endl;
-    expandedMatrix.printExpanded(); // print expanded matrix of 1s 2s and 0s after expandCLEARCOMMENT
+    expandedMatrix.printExpanded();
 
     pBreak();
     cout << "mapFoundation.print()" << endl;
@@ -121,11 +121,13 @@ int Map::getNumNodes() const{return this->nodes->getSize();} // get number of no
 int Map::getNumEdges() const{return this->edges->getSize();} // get number of edges in map (2s = connections/edges between nodes)
 
 // returns coordinate to a select node by index in the array
-Coordinate getSelectNode(int index) const
+Coordinate Map::getSelectNode(int index) const
 {
-    Coordinate badNode(-1,-1);
-    if (this->selectNodes[index] == badNode);
-    return this->selectNodes[0]; // default return if indexing bad node
+    int size = this->selectNodes.getSize();
+
+    if(index<0 || index >= size) {return Coordinate( (-1), (-1) );}
+
+    return this->selectNodes[index]; // default return if indexing bad node
 }
 
 Coordinate Map::getMapStart1() const{return this->start1;} // get defaulted starting coordinate 1
@@ -162,12 +164,6 @@ void Map::set(int x, int y, int value){
         return;
     }
     this->mapData->setCell(x,y,value);
-}
-
-// returns coordinate to a select node by index in the array
-Coordinate getSelectNode(int index) const
-{
-
 }
 
 // set defaulted starting coordinate 1
@@ -227,13 +223,15 @@ bool Map::addEdge(const Coordinate& c){
 }
 
 // print full map with the center location emphasized as @ char
-void Map::print() const{
-
+void Map::print() const
+{
     int rowCounter = 0;
 
     cout << endl << "   ";
     for(int colCounter = 0 ; colCounter < this->mapData->dx ; colCounter++) { cout << colCounter%10 << " ";}
     cout << endl;
+
+    CoordinateArray remainingSelectNodes(this->selectNodes);
 
     for(int y = 0; y<this->mapData->dy; ++y)
     {
@@ -242,29 +240,44 @@ void Map::print() const{
         for(int x = 0; x<this->mapData->dx; ++x)
         {
             if(this->mapData->getCell(x,y)==0){ cout << " ."; }
-            else{
-                if( start1.x==x && start1.y==y )
+            else
+            {
+                bool selectNodeAtCoordinate = false;
+                for(int i = 0 ; i<remainingSelectNodes.getSize() ; ++i)
                 {
-                    cout << " @";    // print start 1 location as a unique character
+                    Coordinate checkNode = remainingSelectNodes[i];
+
+                    if(i==0)    // if the first selectNode will be the Primary selectNode
+                    {
+                        if(checkNode.x==x && checkNode.y==y)
+                        {
+                            cout << " @"; // print start 1 location as a unique character
+                            selectNodeAtCoordinate = true;
+                        }
+                    }
+                    else if(checkNode.x==x && checkNode.y==y)
+                    {
+                        cout << " #";    // print alternative location as a unique character
+                        remainingSelectNodes -= checkNode;
+                        selectNodeAtCoordinate = true;
+                        break;
+                    }
                 }
-                else if( start2.x==x && start2.y==y )
+                if(!selectNodeAtCoordinate)
                 {
-                    cout << " G";    // print start 2 location as a unique character
-                }
-                else
-                {
-                    cout << " "<< this->mapData->getCell(x,y);
+                    cout << " " << this->mapData->getCell(x,y);  // print node as the cell value
                 }
             }
         }
+        cout << endl;
     }
-    cout << endl;
-
 }
 
 void Map::printNodes() const{
     cout << "\nALL NODES" << endl;
     this->nodes->print();
+    cout << "\nALL SELECT NODES" << endl;
+    this->selectNodes.print();
 }
 
 void Map::printEdges() const{
@@ -272,14 +285,27 @@ void Map::printEdges() const{
     this->edges->print();
 }
 
-void printSelectNodes() const
+void Map::printSelectNodes() const
 {
-    cout << "\nALL SELECT NODES" << endl;
-    this->selectNodes.print();
+    cout << endl;
+    int size = this->selectNodes.getSize();
+    for(int i = 0 ; i<size ; ++i)
+    {
+        cout << "   SELECT NODE [" << setw(2) << (i+1) << " ] START: ";
+        if(i == 0)
+        {
+            cout << "@ "; // default primary starting coordinate of map
+        }
+        else
+        {
+            cout << "# "; // default alternative starting coordinate icon on map printout
+        }
+        cout << this->selectNodes[i] << endl;
+    }
 }
 
 void Map::printAdjList() const{
-    cout << "\nALL ADJACENCY DATA" << endl;
+    cout << "\nALL ADJACENCY DATA" << endl << endl;
     int counter = 1;
 
     for (unordered_map<Coordinate, CoordinateArray>::iterator node = this->adjacencyListTable->begin(); node != this->adjacencyListTable->end(); ++node)

--- a/Map.cc
+++ b/Map.cc
@@ -269,8 +269,8 @@ void Map::print() const
                 }
             }
         }
-        cout << endl;
     }
+    cout << endl;
 }
 
 void Map::printNodes() const{

--- a/Map.h
+++ b/Map.h
@@ -4,11 +4,6 @@
 #include "Matrix.h"             // base matrix and expanded matrix
 #include "Coordinate.h"         // 2d coordinate object, PARAMETER ORDERING WILL ALWAYS BE X THEN Y: (x,y)
 
-#define MAP_DEBUG 0                     // debug for only map class 0 == off
-
-#define DEFAULT_DIMENSION 3             // if map obj is instantiated with negative integer dimensions or no dimensions is the default
-#define REMOVE_COMMON_LOOPS 1           // removes small cyclic structures generated on map, makes map with long branches
-
 class MapFoundation;                    // foward declare class for use in ctor
 
 class Map {
@@ -22,6 +17,9 @@ class Map {
 
         unordered_map<Coordinate, CoordinateArray, CoordinateHashFunction> *adjacencyListTable; // hash table storing node adjacency coordinates if an attaches them at a given node in order of ENWS
 
+        int selectNodesCount;               // number of select nodes in the array
+        CoordinateArray selectNodes;        // coordinate array of random nodes designated for unique map features at these nodes
+
         Coordinate start1;            // the coordinate of the spawn room ( around the centre of map ), to get another spawn use getRoom( getNumRooms()-1 )
         Coordinate start2;
 
@@ -30,7 +28,7 @@ class Map {
         void mapDebug(const ExpandedMatrix& expandedMatrix, const MapFoundation& mapFoundation); // prints data at each stage of building the map
 
     public:
-        Map(int maxBaseDimension = DEFAULT_DIMENSION);
+        Map(int maxBaseDimension = DEFAULT_DIMENSION, int numSelectNodes = MINIMUM_SELECT_NODES);
 
         ~Map();
 
@@ -40,6 +38,7 @@ class Map {
         int getNumNodes() const;            // getter size of nodes arr
         int getNumEdges() const;            // getter size of edges arr
 
+        Coordinate getSelectNode(int index) const;  // returns coordinate to a select node by index in the array
         Coordinate getMapStart1() const;        // returns mapStart1
         Coordinate getMapStart2() const;      // returns mapStart2
 
@@ -58,6 +57,7 @@ class Map {
         void print() const;                     // prints the map formatted to include two marked nodes, @ being spawn 1 or mapStart, G being spawn 2 or this->nodes[this->numNodes-1]
         void printNodes() const;                // prints all coordinates of nodes in map
         void printEdges() const;                // prints all coordinates of edges in map
+        void printSelectNodes() const;          // prints all coordinates of selectNodes in map
 
         void printAdjList() const;              // prints all coordinates of nodes adjacent to each node in map
         /*

--- a/Map.h
+++ b/Map.h
@@ -17,13 +17,12 @@ class Map {
 
         unordered_map<Coordinate, CoordinateArray, CoordinateHashFunction> *adjacencyListTable; // hash table storing node adjacency coordinates if an attaches them at a given node in order of ENWS
 
-        int selectNodesCount;               // number of select nodes in the array
         CoordinateArray selectNodes;        // coordinate array of random nodes designated for unique map features at these nodes
 
         Coordinate start1;            // the coordinate of the spawn room ( around the centre of map ), to get another spawn use getRoom( getNumRooms()-1 )
         Coordinate start2;
 
-        void copyMapData(const MapFoundation& mapFoundation); // utility function for copying MapFoundation object data *will throw err if dimension missmatch
+        void copyMapData(const MapFoundation& mapFoundation, int numSelectNodes); // utility function for copying MapFoundation object data *will throw err if dimension missmatch
 
         void mapDebug(const ExpandedMatrix& expandedMatrix, const MapFoundation& mapFoundation); // prints data at each stage of building the map
 
@@ -39,6 +38,7 @@ class Map {
         int getNumEdges() const;            // getter size of edges arr
 
         Coordinate getSelectNode(int index) const;  // returns coordinate to a select node by index in the array
+
         Coordinate getMapStart1() const;        // returns mapStart1
         Coordinate getMapStart2() const;      // returns mapStart2
 
@@ -60,7 +60,4 @@ class Map {
         void printSelectNodes() const;          // prints all coordinates of selectNodes in map
 
         void printAdjList() const;              // prints all coordinates of nodes adjacent to each node in map
-        /*
-        TODO add member/method for adjacency list CoordinateArray for each node, containing data for the edges/nodes connected to each node
-        */
 };

--- a/MapFoundation.h
+++ b/MapFoundation.h
@@ -71,6 +71,7 @@ class MapFoundation {
         missed edges happens due to bidirectional walking and because edges marked visited if they are walked over to next node. If that node in direction is marked visited wont walk there.
         */
         void checkEdges();
+
         bool addUniqueEdge(const Coordinate& currCoord);                // adds coordinates to the edge array if they are not already present, maintaining a set of edge coordinates existing in final map
         bool addUniqueNode(const Coordinate& currCoord);                // adds coordinates to the node array if they are not already present, maintaining a set of node coordinates existing in final map
         bool addUniqueNodeToAdjacencyList(const Coordinate& currCoord, const Coordinate& adjacentCoord); // add to adj list table if it is unique in the given coordinates adjacency list

--- a/MapFoundation.h
+++ b/MapFoundation.h
@@ -4,11 +4,6 @@
 #include "Coordinate.h"
 #include "Matrix.h"
 
-#define MF_DEBUG 0
-#define MF_DEBUG_MAKEMAP 0
-
-#define MAKE_SQUARE 1 //    if final map must be square (for rendering ui is easiest if square) ( const used in MapFoundation::makeMap() )
-
 class Map;
 
 class MapFoundation {

--- a/Matrix.h
+++ b/Matrix.h
@@ -3,14 +3,6 @@
 #include "defs.h"
 #include "Coordinate.h"
 
-#define EDGE 2         // int value for connection between two node elements in matrix
-#define NODE 1         // in the binary matrix, nodes are valued 1 -> expanded maintain value and relative position but are translated
-#define VISITED 2      // visited marking increment for walking the expanded matrix, must be even value >= EDGE
-
-#define EM_DEBUG 0     // debug for this class
-#define OFF_BOUNDS -1  // default int return if off bounds
-
-
 class Matrix {
     protected:
         int* matrix;    // 1 dimensional array of numbers to represent matrix

--- a/Matrix.h
+++ b/Matrix.h
@@ -41,6 +41,7 @@ class Matrix {
 
 
 class ExpandedMatrix : public Matrix {
+
     private:
         int exDx;              // dimension x of this matrix expanded from the base matrix
         int exDy;              // dimension y of this matrix expanded from the base matrix

--- a/README.txt
+++ b/README.txt
@@ -28,10 +28,10 @@ CONSOLE PRINTOUT ON EXECUTION:
 
     1s are nodes
     2s are edges connecting nodes
-    '.' are zeros and are modified only when printed for an easy visual of the map layout
+    '.' are zeros and are modified only in output stream for an easy visual of the map layout
 
-    @ is the primary spawn location for this map
-    # is any additional spawn location for this map (can be more than 1)
+    @ is the primary unique node coordinate for this map
+    # is any unique node coordinate or 'Select Node' for this map (a map can be set to have more than 2)
 
     Map data is translated to the top left of the squared map for purposes of working with a specific gui window
 
@@ -41,7 +41,7 @@ CONSOLE PRINTOUT ON EXECUTION:
 
 
 
-EXAMPLE CONSOLE PRINTOUT [maxBaseDimension = 30]:
+EXAMPLE CONSOLE PRINTOUT with maxBaseDimension = 30, numSelectNodes = 2 :
 
     -------------------------------------
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,8 @@ can compile & execute on LINUX OS, WINDOWS OS, MAC OS
 
 --------------------------------------------------------------------------------------------------------------
 
-TO RUN:
+RUN PROGRAM INSTRUCTIONS:
+
     open console in directory containing Makefile
 
     make executable w. Makefile:
@@ -30,55 +31,14 @@ CONSOLE PRINTOUT ON EXECUTION:
     '.' are zeros and are modified only when printed for an easy visual of the map layout
 
     @ is the primary spawn location for this map
-    G is the secondary spawn location for this map
+    # is any additional spawn location for this map (can be more than 1)
 
-    Map data is translated to the top left of the squared map for purposes of working with a gui window
+    Map data is translated to the top left of the squared map for purposes of working with a specific gui window
 
     Map is randomly generated (in this example time seeded) on each execution using the srand() function
 
 --------------------------------------------------------------------------------------------------------------
 
-ABOUT MAP GENERATION:
-
-    to modify the maximum generated map size, in test.cc change 'maxBaseDimension' value in main() to any
-    desired integer value.
-
-    maxBaseDimension represents the base matrix square dimension n x n that is expanded to
-    ( 2n - 1) x ( 2n - 1) :
-
-        [ Matrix ]                                    [ ExpandedMatrix ] [ if REMOVE_COMMON_LOOPS is set]
-                                 1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
-          1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
-          1 1 1   >> becomes >>  1 . 1 . 1  >> becomes >>   1 2 1 2 1  >> becomes >>      1 . 1 2 1
-          1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
-                                 1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
-
-
-    MapFoundation will walk through the matrix starting at the centre coordinate and mark all nodes
-    connected with edges reachable from the central node, then remove any isolated nodes/edges from
-    the main branching structure.
-
-    MapFoundation will then crop the map and square it based on the largest/smallest x & y coordinates of
-    the entire main branching structure.
-
-    the Map instance uses the MapFoundation instance to build the final map data without
-    including all member functions/variables unusable after making the finalized map.
-
-    when modifying 'maxBaseDimension' Note:
-
-        'maxBaseDimension = 400' means:
-            400x400 base matrix rounded to 399x399 (for a valid centre cell) & expanded to 797x797 before
-            cropping
-
-        maxBaseDimension Expanded becomes:
-            ( maxBaseDimension + (maxBaseDimension - 1) ) ^2 matrix
-
-        at varying maxBaseDimension = 200,300,400, program is unlikely to produce a map larger than 100x100 after
-        cropping
-
-        maxBaseDimension = 400 will start to take a minimum 5-6 s to execute depending on your system
-
---------------------------------------------------------------------------------------------------------------
 
 
 EXAMPLE CONSOLE PRINTOUT [maxBaseDimension = 30]:
@@ -86,7 +46,7 @@ EXAMPLE CONSOLE PRINTOUT [maxBaseDimension = 30]:
     -------------------------------------
 
     ALL ADJACENCY DATA
-    
+
         1 : ( 4,16) = ( 6,16) ( 4,14)
         2 : ( 6,16) = ( 8,16) ( 4,16)
         3 : ( 8,16) = (10,16) ( 6,16)
@@ -164,3 +124,49 @@ EXAMPLE CONSOLE PRINTOUT [maxBaseDimension = 30]:
        SELECT NODE [ 2 ] START: # ( 0, 8)
 
     -------------------------------------
+
+
+
+--------------------------------------------------------------------------------------------------------------
+
+ABOUT MAP GENERATION:
+
+    to modify the maximum generated map size, in test.cc change 'maxBaseDimension' value in main() to any
+    desired integer value.
+
+    maxBaseDimension represents the base matrix square dimension n x n that is expanded to
+    ( 2n - 1) x ( 2n - 1) :
+
+        [ Matrix ]                                    [ ExpandedMatrix ] [ if REMOVE_COMMON_LOOPS is set]
+                                 1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
+          1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
+          1 1 1   >> becomes >>  1 . 1 . 1  >> becomes >>   1 2 1 2 1  >> becomes >>      1 . 1 2 1
+          1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
+                                 1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
+
+
+    MapFoundation will walk through the matrix starting at the centre coordinate and mark all nodes
+    connected with edges reachable from the central node, then remove any isolated nodes/edges from
+    the main branching structure.
+
+    MapFoundation will then crop the map and square it based on the largest/smallest x & y coordinates of
+    the entire main branching structure.
+
+    the Map instance uses the MapFoundation instance to build the final map data without
+    including all member functions/variables unusable after making the finalized map.
+
+    when modifying 'maxBaseDimension' Note:
+
+        'maxBaseDimension = 400' means:
+            400x400 base matrix rounded to 399x399 (for a valid centre cell) & expanded to 797x797 before
+            cropping
+
+        maxBaseDimension Expanded becomes:
+            ( maxBaseDimension + (maxBaseDimension - 1) ) ^2 matrix
+
+        at varying maxBaseDimension = 200,300,400, program is unlikely to produce a map larger than 100x100 after
+        cropping
+
+        maxBaseDimension = 400 will start to take a minimum 5-6 s to execute depending on your system
+
+--------------------------------------------------------------------------------------------------------------

--- a/README.txt
+++ b/README.txt
@@ -25,143 +25,142 @@ TO RUN:
 
 CONSOLE PRINTOUT ON EXECUTION:
 
-1s are nodes
-2s are edges connecting nodes
-'.' are zeros and are modified only when printed for an easy visual of the map layout
+    1s are nodes
+    2s are edges connecting nodes
+    '.' are zeros and are modified only when printed for an easy visual of the map layout
 
-@ is the primary spawn location for this map
-G is the secondary spawn location for this map
+    @ is the primary spawn location for this map
+    G is the secondary spawn location for this map
 
-Map data is translated to the top left of the squared map for purposes of working with a gui window
+    Map data is translated to the top left of the squared map for purposes of working with a gui window
 
-Map is randomly generated (in this example time seeded) on each execution using the srand() function
+    Map is randomly generated (in this example time seeded) on each execution using the srand() function
 
 --------------------------------------------------------------------------------------------------------------
 
-ABOUT THE MAP:
+ABOUT MAP GENERATION:
 
-to modify the maximum generated map size, in test.cc change 'maxBaseDimension' value in main() to any desired
-integer value.
+    to modify the maximum generated map size, in test.cc change 'maxBaseDimension' value in main() to any
+    desired integer value.
 
-maxBaseDimension represents the base matrix square dimension n x n that is expanded to ( 2n - 1) x ( 2n - 1) :
+    maxBaseDimension represents the base matrix square dimension n x n that is expanded to
+    ( 2n - 1) x ( 2n - 1) :
 
-[ Matrix ]                                       [ ExpandedMatrix ] [ if REMOVE_COMMON_LOOPS constant is set ]
-                         1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
-  1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
-  1 1 1   >> becomes >>  1 . 1 . 1  >> becomes >>   1 2 1 2 1  >> becomes >>      1 . 1 2 1
-  1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
-                         1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
+        [ Matrix ]                                    [ ExpandedMatrix ] [ if REMOVE_COMMON_LOOPS is set]
+                                 1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
+          1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
+          1 1 1   >> becomes >>  1 . 1 . 1  >> becomes >>   1 2 1 2 1  >> becomes >>      1 . 1 2 1
+          1 1 1                  . . . . .                  2 . 2 . 2                     2 . 2 . 2
+                                 1 . 1 . 1                  1 2 1 2 1                     1 2 1 . 1
 
 
-MapFoundation will walk through the matrix starting at the centre coordinate and mark all nodes
-connected with edges reachable from the central node, then remove any isolated nodes/edges from
-the main branching structure.
+    MapFoundation will walk through the matrix starting at the centre coordinate and mark all nodes
+    connected with edges reachable from the central node, then remove any isolated nodes/edges from
+    the main branching structure.
 
-MapFoundation will then crop the map and square it based on the largest/smallest x & y coordinates of
-the entire main branching structure.
+    MapFoundation will then crop the map and square it based on the largest/smallest x & y coordinates of
+    the entire main branching structure.
 
-the Map instance uses the MapFoundation instance to build the final map data without
-including all member functions/variables unusable after making the finalized map.
+    the Map instance uses the MapFoundation instance to build the final map data without
+    including all member functions/variables unusable after making the finalized map.
 
-when modifying 'maxBaseDimension' Note:
+    when modifying 'maxBaseDimension' Note:
 
-    'maxBaseDimension = 400' means:
-        400x400 base matrix rounded to 399x399 (for a valid centre cell) & expanded to 797x797 before cropping
+        'maxBaseDimension = 400' means:
+            400x400 base matrix rounded to 399x399 (for a valid centre cell) & expanded to 797x797 before
+            cropping
 
-    maxBaseDimension Expanded Becomes:
-        ( maxBaseDimension + (maxBaseDimension - 1) ) ^2 matrix
+        maxBaseDimension Expanded becomes:
+            ( maxBaseDimension + (maxBaseDimension - 1) ) ^2 matrix
 
-    at varying maxBaseDimension = 200,300,400, it is unlikely to produce a map larger than 100x100 after
-    cropping
+        at varying maxBaseDimension = 200,300,400, program is unlikely to produce a map larger than 100x100 after
+        cropping
 
-    maxBaseDimension = 400 will start to take a minimum 5-6 s to execute depending on your system
+        maxBaseDimension = 400 will start to take a minimum 5-6 s to execute depending on your system
 
 --------------------------------------------------------------------------------------------------------------
 
 
 EXAMPLE CONSOLE PRINTOUT [maxBaseDimension = 30]:
 
--------------------------------------------------
+    -------------------------------------
 
-ALL ADJACENCY DATA
-    1 : (14,18) = (16,18) (14,16)
-    2 : (16,16) = (14,16)
-    3 : (16,18) = (14,18)
-    4 : (20,16) = (20,14)
-    5 : (14,16) = (16,16) (14,14) (14,18)
-    6 : (20,14) = (20,12) (20,16)
-    7 : (20,12) = (22,12) (20,10) (20,14)
-    8 : (18,12) = (18,10)
-    9 : (18,10) = (20,10) (18, 8) (16,10) (18,12)
-   10 : (16,10) = (18,10) (16, 8)
-   11 : (18, 8) = (18,10)
-   12 : (14, 6) = (16, 6) (12, 6) (14, 8)
-   13 : (12, 6) = (14, 6)
-   14 : (20,10) = (18,10) (20,12)
-   15 : (16, 8) = (14, 8) (16,10)
-   16 : (16, 4) = (18, 4) (16, 6)
-   17 : (12,10) = (12, 8)
-   18 : ( 8, 8) = (10, 8) ( 8,10)
-   19 : ( 4,14) = ( 4,12) ( 2,14)
-   20 : (18, 4) = (18, 2) (16, 4)
-   21 : (10, 8) = (12, 8) ( 8, 8)
-   22 : ( 2,12) = ( 4,12)
-   23 : ( 2,14) = ( 4,14) ( 0,14)
-   24 : (14, 8) = (16, 8) (14, 6) (12, 8)
-   25 : ( 6,12) = ( 8,12) ( 4,12)
-   26 : (22,12) = (20,12)
-   27 : ( 2, 6) = ( 2, 8)
-   28 : (14,14) = (14,12) (12,14) (14,16)
-   29 : (10,12) = (10,14)
-   30 : ( 2, 8) = ( 4, 8) ( 2, 6)
-   31 : ( 0,14) = ( 2,14)
-   32 : (16, 6) = (16, 4) (14, 6)
-   33 : (12, 8) = (14, 8) (10, 8) (12,10)
-   34 : ( 8,10) = ( 8, 8) ( 8,12)
-   35 : ( 4,12) = ( 6,12) ( 4,10) ( 2,12) ( 4,14)
-   36 : (16, 2) = (18, 2) (16, 0)
-   37 : ( 8,14) = (10,14) ( 8,12)
-   38 : ( 4, 8) = ( 2, 8) ( 4,10)
-   39 : ( 0,10) = ( 2,10)
-   40 : (16, 0) = (16, 2)
-   41 : (12,14) = (14,14) (10,14)
-   42 : ( 8,12) = ( 8,10) ( 6,12) ( 8,14)
-   43 : ( 4,10) = ( 4, 8) ( 2,10) ( 4,12)
-   44 : (18, 2) = (16, 2) (18, 4)
-   45 : (14,12) = (14,14)
-   46 : (10,14) = (12,14) (10,12) ( 8,14)
-   47 : ( 2,10) = ( 4,10) ( 0,10)
+    ALL ADJACENCY DATA
+    
+        1 : ( 4,16) = ( 6,16) ( 4,14)
+        2 : ( 6,16) = ( 8,16) ( 4,16)
+        3 : ( 8,16) = (10,16) ( 6,16)
+        4 : (10,16) = (10,14) ( 8,16)
+        5 : ( 0, 8) = ( 2, 8)
+        6 : ( 4,10) = ( 6,10) ( 2,10)
+        7 : (12,14) = (10,14)
+        8 : ( 6, 8) = ( 6,10)
+        9 : ( 2,10) = ( 4,10) ( 2, 8) ( 2,12)
+       10 : (10,14) = (12,14) (10,12) (10,16)
+       11 : ( 6,10) = ( 6, 8) ( 4,10) ( 6,12)
+       12 : ( 2, 8) = ( 0, 8) ( 2,10)
+       13 : (10,12) = (10,10) (10,14)
+       14 : ( 6,12) = ( 6,10)
+       15 : ( 2,14) = ( 4,14) ( 2,12)
+       16 : (14, 8) = (14,10)
+       17 : (10,10) = (12,10) (10, 8) (10,12)
+       18 : ( 8, 0) = ( 8, 2)
+       19 : ( 8, 2) = ( 8, 0) ( 6, 2) ( 8, 4)
+       20 : ( 4,14) = ( 2,14) ( 4,16)
+       21 : (12,10) = (14,10) (12, 8) (10,10)
+       22 : ( 6, 2) = ( 8, 2)
+       23 : (10, 4) = (12, 4) (10, 6)
+       24 : ( 2,12) = ( 2,10) ( 2,14)
+       25 : (14,10) = (14, 8) (12,10)
+       26 : (10, 8) = (10, 6) (10,10)
+       27 : ( 8, 6) = (10, 6) ( 8, 4)
+       28 : (12, 4) = (10, 4) (12, 6)
+       29 : ( 8, 4) = ( 8, 2) ( 8, 6)
+       30 : (12, 6) = (12, 4) (12, 8)
+       31 : (10, 6) = (10, 4) ( 8, 6) (10, 8)
+       32 : (12, 8) = (12, 6) (12,10)
 
--------------------------------------------------
+    -------------------------------------
 
-   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2
+       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6
 
-0  . . . . . . . . . . . . . . . . 1 . . . . . .
-1  . . . . . . . . . . . . . . . . 2 . . . . . .
-2  . . . . . . . . . . . . . . . . 1 2 1 . . . .
-3  . . . . . . . . . . . . . . . . . . 2 . . . .
-4  . . . . . . . . . . . . . . . . 1 2 1 . . . .
-5  . . . . . . . . . . . . . . . . 2 . . . . . .
-6  . . 1 . . . . . . . . . 1 2 1 2 1 . . . . . .
-7  . . 2 . . . . . . . . . . . 2 . . . . . . . .
-8  . . 1 2 1 . . . 1 2 1 2 1 2 1 2 1 . 1 . . . .
-9  . . . . 2 . . . 2 . . . 2 . . . 2 . 2 . . . .
-0  1 2 @ 2 1 . . . 1 . . . 1 . . . 1 2 1 2 1 . .
-1  . . . . 2 . . . 2 . . . . . . . . . 2 . 2 . .
-2  . . 1 2 1 2 1 2 1 . 1 . . . 1 . . . 1 . 1 2 1
-3  . . . . 2 . . . 2 . 2 . . . 2 . . . . . 2 . .
-4  1 2 1 2 1 . . . 1 2 1 2 1 2 1 . . . . . 1 . .
-5  . . . . . . . . . . . . . . 2 . . . . . 2 . .
-6  . . . . . . . . . . . . . . 1 2 1 . . . 1 . .
-7  . . . . . . . . . . . . . . 2 . . . . . . . .
-8  . . . . . . . . . . . . . . 1 2 G . . . . . .
-9  . . . . . . . . . . . . . . . . . . . . . . .
-0  . . . . . . . . . . . . . . . . . . . . . . .
-1  . . . . . . . . . . . . . . . . . . . . . . .
-2  . . . . . . . . . . . . . . . . . . . . . . .
+    0  . . . . . . . . 1 . . . . . . . .
 
--------------------------------------------------
-   ENTITY SPAWN1 START: @ ( 2,10)
-   ENTITY SPAWN2 START: G (16,18)
+    1  . . . . . . . . 2 . . . . . . . .
 
--------------------------------------------------
+    2  . . . . . . 1 2 1 . . . . . . . .
+
+    3  . . . . . . . . 2 . . . . . . . .
+
+    4  . . . . . . . . 1 . 1 2 1 . . . .
+
+    5  . . . . . . . . 2 . 2 . 2 . . . .
+
+    6  . . . . . . . . 1 2 1 . 1 . . . .
+
+    7  . . . . . . . . . . 2 . 2 . . . .
+
+    8  # 2 1 . . . 1 . . . 1 . @ . 1 . .
+
+    9  . . 2 . . . 2 . . . 2 . 2 . 2 . .
+
+    0  . . 1 2 1 2 1 . . . 1 2 1 2 1 . .
+
+    1  . . 2 . . . 2 . . . 2 . . . . . .
+
+    2  . . 1 . . . 1 . . . 1 . . . . . .
+
+    3  . . 2 . . . . . . . 2 . . . . . .
+
+    4  . . 1 2 1 . . . . . 1 2 1 . . . .
+
+    5  . . . . 2 . . . . . 2 . . . . . .
+
+    6  . . . . 1 2 1 2 1 2 1 . . . . . .
+
+    -------------------------------------
+
+       SELECT NODE [ 1 ] START: @ (12, 8)
+       SELECT NODE [ 2 ] START: # ( 0, 8)
+
+    -------------------------------------

--- a/README.txt
+++ b/README.txt
@@ -41,7 +41,7 @@ CONSOLE PRINTOUT ON EXECUTION:
 
 
 
-EXAMPLE CONSOLE PRINTOUT with maxBaseDimension = 30, numSelectNodes = 2 :
+EXAMPLE CONSOLE PRINTOUT with maxBaseDimensionOfMatrix = 30, numSelectNodes = 2 :
 
     -------------------------------------
 
@@ -85,37 +85,21 @@ EXAMPLE CONSOLE PRINTOUT with maxBaseDimension = 30, numSelectNodes = 2 :
        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6
 
     0  . . . . . . . . 1 . . . . . . . .
-
     1  . . . . . . . . 2 . . . . . . . .
-
     2  . . . . . . 1 2 1 . . . . . . . .
-
     3  . . . . . . . . 2 . . . . . . . .
-
     4  . . . . . . . . 1 . 1 2 1 . . . .
-
     5  . . . . . . . . 2 . 2 . 2 . . . .
-
     6  . . . . . . . . 1 2 1 . 1 . . . .
-
     7  . . . . . . . . . . 2 . 2 . . . .
-
     8  # 2 1 . . . 1 . . . 1 . @ . 1 . .
-
     9  . . 2 . . . 2 . . . 2 . 2 . 2 . .
-
     0  . . 1 2 1 2 1 . . . 1 2 1 2 1 . .
-
     1  . . 2 . . . 2 . . . 2 . . . . . .
-
     2  . . 1 . . . 1 . . . 1 . . . . . .
-
     3  . . 2 . . . . . . . 2 . . . . . .
-
     4  . . 1 2 1 . . . . . 1 2 1 . . . .
-
     5  . . . . 2 . . . . . 2 . . . . . .
-
     6  . . . . 1 2 1 2 1 2 1 . . . . . .
 
     -------------------------------------
@@ -131,10 +115,10 @@ EXAMPLE CONSOLE PRINTOUT with maxBaseDimension = 30, numSelectNodes = 2 :
 
 ABOUT MAP GENERATION:
 
-    to modify the maximum generated map size, in test.cc change 'maxBaseDimension' value in main() to any
+    to modify the maximum generated map size, in test.cc change 'maxBaseDimensionOfMatrix' value in main() to any
     desired integer value.
 
-    maxBaseDimension represents the base matrix square dimension n x n that is expanded to
+    maxBaseDimensionOfMatrix represents the base matrix square dimension n x n that is expanded to
     ( 2n - 1) x ( 2n - 1) :
 
         [ Matrix ]                                    [ ExpandedMatrix ] [ if REMOVE_COMMON_LOOPS is set]
@@ -152,21 +136,21 @@ ABOUT MAP GENERATION:
     MapFoundation will then crop the map and square it based on the largest/smallest x & y coordinates of
     the entire main branching structure.
 
-    the Map instance uses the MapFoundation instance to build the final map data without
-    including all member functions/variables unusable after making the finalized map.
+    the Map instance uses the MapFoundation instance to build all final map data with abstraction from
+    the member functions/variables used in the generation process
 
-    when modifying 'maxBaseDimension' Note:
+    when modifying 'maxBaseDimensionOfMatrix' :
 
-        'maxBaseDimension = 400' means:
+        'maxBaseDimensionOfMatrix = 400' means:
             400x400 base matrix rounded to 399x399 (for a valid centre cell) & expanded to 797x797 before
             cropping
 
-        maxBaseDimension Expanded becomes:
-            ( maxBaseDimension + (maxBaseDimension - 1) ) ^2 matrix
+        OR maxBaseDimensionOfMatrix Expanded becomes:
+            ( maxBaseDimensionOfMatrix + (maxBaseDimensionOfMatrix - 1) )^2 for the full matrix dimension
 
-        at varying maxBaseDimension = 200,300,400, program is unlikely to produce a map larger than 100x100 after
-        cropping
+        varying maxBaseDimensionOfMatrix to have a value of 200,300,400, will likely to produce a map of size 100x100
+        after cropping
 
-        maxBaseDimension = 400 will start to take a minimum 5-6 s to execute depending on your system
+        maxBaseDimensionOfMatrix = 400 will start to take a minimum 5-6 s to execute depending on your system
 
 --------------------------------------------------------------------------------------------------------------

--- a/defs.h
+++ b/defs.h
@@ -30,5 +30,4 @@
 
 #define OFF_BOUNDS              -1     // default int return if off bounds when accessing a coordinate cell value in the matrix
 
-
 using namespace std;

--- a/defs.h
+++ b/defs.h
@@ -6,7 +6,29 @@
 #include <unordered_map> // for hash map
 #include <iomanip>       // for setw and setfill
 
-#define DEBUG 0               // alot of printout try with smallest (n x n = 3 x 3) dimension size for map object
-#define DEFAULT_ARRAY_SIZE 32 // default size of array backing of collection objects before they need to resize
+
+// DEBUG FLAGS
+#define DEBUG                   0      // MASTER DEBUG FOR EXECUTION ORDER OF FUNCTIONS
+#define MAP_DEBUG               0      // debug for Map class member functions 0 == off
+
+#define MF_DEBUG                0      // debug for MapFoundation class member functions 0 == off
+#define MF_DEBUG_MAKEMAP        0      // debug for MapFoundation class makeMap function only 0 == off
+
+#define EM_DEBUG                0      // debug for ExpandedMatrix class member functions 0 == off
+
+#define DEFAULT_ARRAY_SIZE      32     // default size of array backing of collection objects before they need to resize
+
+#define DEFAULT_DIMENSION       3      // if map obj is instantiated with negative integer dimensions or no dimensions is the default
+#define MINIMUM_SELECT_NODES    2      // number of select nodes in the map for unique map features at these nodes
+#define REMOVE_COMMON_LOOPS     1      // removes small cyclic structures generated on map, makes map with long branches
+
+#define MAKE_SQUARE             1      // if final map must be square (for rendering ui is easiest if square) ( const used in MapFoundation::makeMap() )
+
+#define EDGE                    2      // int value for connection between two node elements in matrix
+#define NODE                    1      // in the binary matrix, nodes are valued 1 -> expanded maintain value and relative position but are translated
+#define VISITED                 2      // visited marking increment for walking the expanded matrix, must be even value >= EDGE
+
+#define OFF_BOUNDS              -1     // default int return if off bounds when accessing a coordinate cell value in the matrix
+
 
 using namespace std;

--- a/test.cc
+++ b/test.cc
@@ -14,23 +14,16 @@ int main()
         -> randomly generated map will crop out unconnected nodes to the main map
     */
     int maxBaseDimension = 30;
-    Map map(maxBaseDimension,5);  // create map object
+    Map map(maxBaseDimension);  // create map object
 
     printBreak(map);
     map.printAdjList();         // print the adjacency list first
     printBreak(map);
 
-    map.printNodes();
+    map.print();                // print 2d visual of map object formatted with coordinate display
     printBreak(map);
 
-    map.printSelectNodes();
-    printBreak(map);
-
-    map.print();                // print map object
-    printBreak(map);
-
-    cout << "   ENTITY SPAWN1 START: @ " << map.getMapStart1() << endl;     // default primary starting coordinate of map
-    cout << "   ENTITY SPAWN2 START: G " << map.getMapStart2() << endl;     // default secondary starting coordinate of map
+    map.printSelectNodes();     // print the coordinates of select nodes in map
     printBreak(map);
 
     return 0;
@@ -40,7 +33,7 @@ int main()
 // formatted console printout utility function
 void printBreak(const Map& map)
 {
-    int size = 2*map.getXDim() + 3;
+    int size = 2*map.getXDim() + 3; // magic numbers correspond to size of formatted output spacing and coordinate display
     cout << endl;
     for(int i = 0 ; i < size ; ++i) { cout << "-"; }
     cout << endl;

--- a/test.cc
+++ b/test.cc
@@ -14,10 +14,16 @@ int main()
         -> randomly generated map will crop out unconnected nodes to the main map
     */
     int maxBaseDimension = 30;
-    Map map(maxBaseDimension);  // create map object
+    Map map(maxBaseDimension,5);  // create map object
 
     printBreak(map);
     map.printAdjList();         // print the adjacency list first
+    printBreak(map);
+
+    map.printNodes();
+    printBreak(map);
+
+    map.printSelectNodes();
     printBreak(map);
 
     map.print();                // print map object

--- a/test.cc
+++ b/test.cc
@@ -9,12 +9,18 @@ int main()
     srand(static_cast<unsigned int>(time(nullptr))); // seed random with current system time
 
     /*
-    determines max size of map on random generation
+    maxBaseDimension is a factor in determining the maximum size of final map on random generation
         -> base dimension becomes expanded to: maxBaseDimension + (maxBaseDimension-1)
         -> randomly generated map will crop out unconnected nodes to the main map
+
+    numberOfSpawnLocations determines how many spawn locations are stored in the map
+        -> minimum is 2
+        -> maximum is the number of nodes generated on the map
     */
-    int maxBaseDimension = 30;
-    Map map(maxBaseDimension);  // create map object
+    int maxBaseDimensionOfMatrix = 30;
+    int numberOfSpawnLocations = 2;
+
+    Map map(maxBaseDimension,numberOfSpawnLocations);  // create map object
 
     printBreak(map);
     map.printAdjList();         // print the adjacency list first

--- a/test.cc
+++ b/test.cc
@@ -6,7 +6,7 @@ void printBreak(const Map& map);               // formatted console printout uti
 
 int main()
 {
-    srand(static_cast<unsigned int>(time(nullptr))); // seed random with current system time
+    srand( static_cast<unsigned int>(time(nullptr)) ); // seed random with current system time
 
     /*
     maxBaseDimension is a factor in determining the maximum size of final map on random generation
@@ -20,7 +20,7 @@ int main()
     int maxBaseDimensionOfMatrix = 30;
     int numberOfSpawnLocations = 2;
 
-    Map map(maxBaseDimension,numberOfSpawnLocations);  // create map object
+    Map map( maxBaseDimensionOfMatrix, numberOfSpawnLocations );  // create map object
 
     printBreak(map);
     map.printAdjList();         // print the adjacency list first
@@ -37,7 +37,7 @@ int main()
 
 
 // formatted console printout utility function
-void printBreak(const Map& map)
+void printBreak( const Map& map )
 {
     int size = 2*map.getXDim() + 3; // magic numbers correspond to size of formatted output spacing and coordinate display
     cout << endl;

--- a/test.cc
+++ b/test.cc
@@ -13,7 +13,7 @@ int main()
         -> base dimension becomes expanded to: maxBaseDimension + (maxBaseDimension-1)
         -> randomly generated map will crop out unconnected nodes to the main map
 
-    numberOfSpawnLocations determines how many spawn locations are stored in the map
+    numberOfSpawnLocations determines how many unique nodes are stored in the map
         -> minimum is 2
         -> maximum is the number of nodes generated on the map
     */


### PR DESCRIPTION
Select Node Added: implementation for modular addition of unique spawn points in the map + various improvements

**SELECT NODE:**
* a node of interest in the map stored as a coordinate at a fixed index 
* the select node has applications as fixed spawn points for teams or unique entities or objects in the map upon generation
* allows for as many select nodes as there are nodes in the array whereas previously the select nodes were hard coded coordinate members of the map object

**VARIOUS IMPROVEMENTS:**
* added remove from back implementation for CoordinateArray
* CoordinateArray copy ctor now is pass by const reference and not pointer (issues with deep copy vs shallow)
* improved formatting for map printouts
* added formatted printing for SelectNode prinouts
* added / improved in readme file